### PR TITLE
feat(gateway): add security rules for company image upload and increase multipart buffer size

### DIFF
--- a/src/main/java/com/oneClick/gatewayService/config/SecurityConfig.java
+++ b/src/main/java/com/oneClick/gatewayService/config/SecurityConfig.java
@@ -51,9 +51,16 @@ public class SecurityConfig {
                 .cors(cors -> cors.configurationSource(corsConfigurationSource())) // ← CORS từ env
                 .csrf(ServerHttpSecurity.CsrfSpec::disable)
                 .authorizeExchange(exchanges -> exchanges
-                        .pathMatchers(HttpMethod.OPTIONS, "/**").permitAll() // ← Preflight OK
-                        .pathMatchers("/ws/**").permitAll()  // Thêm /ws/**
+                        .pathMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                        .pathMatchers("/ws/**").permitAll()
                         .pathMatchers("/api/auth/**", "/actuator/**").permitAll()
+                        .pathMatchers(HttpMethod.PUT,
+                                "/api/recruitment/company/logo/upload",
+                                "/api/recruitment/company/background/upload")
+                        .hasAuthority("ROLE_recruiter")
+                        .pathMatchers(HttpMethod.GET, "/api/recruitment/company/**").permitAll()
+                        .pathMatchers(HttpMethod.GET, "/api/recruitment/job/**").permitAll()
+
                         .pathMatchers("/api/recruitment/candidate/**").hasAuthority("ROLE_candidate")
                         .pathMatchers("/api/recruitment/employer/**").hasAuthority("ROLE_recruiter")
                         .pathMatchers("/api/admin/**").hasAuthority("ROLE_admin")

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -11,6 +11,10 @@ spring:
   application:
     name: ${APP_NAME:gateway-service}
 
+  # Tăng buffer size cho multipart upload (default 256KB → 10MB)
+  codec:
+    max-in-memory-size: 10MB
+
   cloud:
     compatibility-verifier:
       enabled: false
@@ -18,6 +22,10 @@ spring:
       logging:
         enabled: true
     gateway:
+      # Cho phép multipart/form-data forwarding (upload ảnh company logo/background)
+      streaming-media-types:
+        - multipart/form-data
+        - application/octet-stream
       default-filters:
         - DedupeResponseHeader=Access-Control-Allow-Origin Access-Control-Allow-Credentials Vary, RETAIN_FIRST
 


### PR DESCRIPTION
- Allow recruiter role to PUT company logo/background upload endpoints
- Permit public GET access to company and job recruitment endpoints
- Increase max-in-memory-size to 10MB for multipart upload
- Add multipart/form-data and octet-stream as streaming media types

#22 
@BuiHoangVuong777 